### PR TITLE
Properly detect all derivatives of Spigot

### DIFF
--- a/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
+++ b/src/main/java/io/github/rypofalem/armorstandeditor/ArmorStandEditorPlugin.java
@@ -85,7 +85,7 @@ public class ArmorStandEditorPlugin extends JavaPlugin{
 
 		hasSpigot = true;
 		try {
-			Class.forName("org.spigotmc.package-info", false, this.getClassLoader());
+			Class.forName("org.spigotmc.SpigotConfig", false, this.getClassLoader());
 		} catch (ClassNotFoundException e) {
 			hasSpigot = false;
 		}


### PR DESCRIPTION
Not all implementations contain a package-info class, but they all contain the SpigotConfig class